### PR TITLE
WIP: Simplify Espresso routing model

### DIFF
--- a/build/site_test.go
+++ b/build/site_test.go
@@ -22,15 +22,15 @@ func TestRegisterPage(t *testing.T) {
 		Article: model.Article{ID: "about-me"},
 	})
 
-	if _, ok := site.root.Children["content"]; !ok {
+	if _, ok := site.routes["content"]; !ok {
 		t.Errorf("Could not find %s segment", "content")
 	}
 
-	if _, ok := site.root.Children["content"].Children["coffee"]; !ok {
+	if _, ok := site.routes["content/coffee"]; !ok {
 		t.Errorf("Could not find %s segment", "coffee")
 	}
 
-	if len(site.root.Children["content"].Children["coffee"].Pages) < 1 {
+	if len(site.routes["content/coffee"].Pages) < 1 {
 		t.Errorf("Could not find page under %s", "content/coffee")
 	}
 }

--- a/render/render.go
+++ b/render/render.go
@@ -45,12 +45,12 @@ func AsWebsite(ctx Context, site *build.Site) error {
 // streamPages walks down the route tree and sends all pages through
 // the pages channel, which is used to receive and build these pages.
 func streamPages(ctx *Context, site *build.Site, pages chan<- *model.ArticlePage) {
-	site.WalkRoutes(func(r *build.Route) {
-		for _, page := range r.Pages {
+	site.WalkRoutes(func(r string, i *build.RouteInfo) {
+		for _, page := range i.Pages {
 			pages <- page
 		}
-		_ = renderArticleListPage(ctx, r.ListPage)
-	}, -1)
+		_ = renderArticleListPage(ctx, i.ListPage)
+	})
 
 	close(pages)
 }


### PR DESCRIPTION
This PR introduces a set of changes that aim to simplify Espresso's routing model. Instead of maintaining a routing tree, all route paths are registered as a map that holds the pages under the particular routes as values. The goal is to wipe out all tree traversals.